### PR TITLE
Refactor Renovate configuration to simplify Docker Compose updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,15 +8,7 @@
   "packageRules": [
     {
       "description": "Group Docker image updates for docker-compose files",
-      "matchFiles": [
-        "**/docker-compose/**/*.yml", 
-        "**/docker-compose/**/*.yaml",
-        "**/backups/*.yml",
-        "**/infrastructure/*.yml",
-        "**/monitoring/*.yml",
-        "**/media/*.yml",
-        "**/development/*.yml"
-      ],
+      "matchManagers": ["docker-compose"],
       "groupName": "Docker Compose dependencies",
       "schedule": ["on sunday"]
     },
@@ -76,15 +68,7 @@
   "gitAuthor": "Renovate Bot <noreply@github.com>",
   
   "docker-compose": {
-    "fileMatch": [
-      "**/docker-compose/**/*.yml",
-      "**/docker-compose/**/*.yaml",
-      "**/backups/*.yml",
-      "**/infrastructure/*.yml",
-      "**/monitoring/*.yml",
-      "**/media/*.yml",
-      "**/development/*.yml"
-    ]
+    "enabled": true
   },
   
   "ignorePresets": [


### PR DESCRIPTION
- Changed `matchFiles` to `matchManagers` for Docker Compose, streamlining the update process.
- Enabled Docker Compose configuration in `renovate.json` for better management of dependencies.